### PR TITLE
avoid error from pyserial when opening port

### DIFF
--- a/TrinketFakeUsbSerialHostSW/TrinketFakeUsbSerialHostSW_Python/TrinketFakeUsbSerialHostSW.py
+++ b/TrinketFakeUsbSerialHostSW/TrinketFakeUsbSerialHostSW_Python/TrinketFakeUsbSerialHostSW.py
@@ -52,7 +52,7 @@ def main(argv):
         print 'TrinketFakeUsbSerialHostSW Python Edition'
         print 'port is ', port
 
-    ser = serial.Serial(port)
+    ser = serial.Serial(port, dsrdtr=True, rtscts=True)
     if verbose and port != ser.portstr:
         print 'port actually is ', ser.portstr
 


### PR DESCRIPTION
c.f. https://github.com/ecc1/decoding-carelink/commit/fa739aed00e2efe4ee7e7e20fe05f9b907f4f8eb
https://github.com/pyserial/pyserial/issues/59
